### PR TITLE
patch Parse module for iOS 14 and xcode 12.2

### DIFF
--- a/DVIA-v2/Pods/Parse/Parse/Parse/ParseClientConfiguration.m
+++ b/DVIA-v2/Pods/Parse/Parse/Parse/ParseClientConfiguration.m
@@ -126,18 +126,18 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 ///--------------------------------------
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    return [ParseClientConfiguration configurationWithBlock:^(ParseClientConfiguration *configuration) {
-        // Use direct assignment to skip over all of the assertions that may fail if we're not fully initialized yet.
-        configuration->_applicationId = [self->_applicationId copy];
-        configuration->_clientKey = [self->_clientKey copy];
-        configuration->_server = [self.server copy];
-        configuration->_fileUploadController = self->_fileUploadController;
-        configuration->_localDatastoreEnabled = self->_localDatastoreEnabled;
-        configuration->_applicationGroupIdentifier = [self->_applicationGroupIdentifier copy];
-        configuration->_containingApplicationBundleIdentifier = [self->_containingApplicationBundleIdentifier copy];
-        configuration->_networkRetryAttempts = self->_networkRetryAttempts;
-        configuration->_URLSessionConfiguration = self->_URLSessionConfiguration;
-    }];
-}
+    ParseClientConfiguration *const configuration = [[ParseClientConfiguration alloc] initEmpty];
+    if (!configuration) return nil;
+    // Use direct assignment to skip over all of the assertions that may fail if we're not fully initialized yet.
+    configuration->_applicationId = [self->_applicationId copy];
+    configuration->_clientKey = [self->_clientKey copy];
+    configuration->_server = [self.server copy];
+    configuration->_fileUploadController = self->_fileUploadController;
+    configuration->_localDatastoreEnabled = self->_localDatastoreEnabled;
+    configuration->_applicationGroupIdentifier = [self->_applicationGroupIdentifier copy];
+    configuration->_containingApplicationBundleIdentifier = [self->_containingApplicationBundleIdentifier copy];
+    configuration->_networkRetryAttempts = self->_networkRetryAttempts;
+    configuration->_URLSessionConfiguration = self->_URLSessionConfiguration;
+    return configuration;}
 
 @end


### PR DESCRIPTION
Couldn't drag-n-drop original .app to Simulator, but after these changes compilation via xcode works seamlessly!