### PR TITLE
Fix detect_injected_dylds

### DIFF
--- a/DVIA-v2/DVIA-v2/Vulnerabilities/AntiAntiHookingDebugging/anti.c
+++ b/DVIA-v2/DVIA-v2/Vulnerabilities/AntiAntiHookingDebugging/anti.c
@@ -56,7 +56,7 @@ int detect_injected_dylds()
         const char *dyld = _dyld_get_image_name(i);
        // printf("LibraryName:%s\n",basename(dyld));
         //Cycript for RuntimeManipulation, MobileSubstrate for any form of injection, and SSLKillSwitch2 if someone tries to bypas SSLPinning, additionally these stings can be obfuscated in the code as well
-        if(!strstr(dyld, "MobileSubstrate") || !strstr(dyld, "cycript") || !strstr(dyld, "SSLKillSwitch") || !strstr(dyld, "SSLKillSwitch2")) {
+        if(!strstr(dyld, "MobileSubstrate") && !strstr(dyld, "cycript") && !strstr(dyld, "SSLKillSwitch") && !strstr(dyld, "SSLKillSwitch2")) {
             continue;
         }
         else {


### PR DESCRIPTION
I found this bug when using Choicy 1.4.10 that injects a library: "/Library/MobileSubstrate/DynamicLibraries/\ \ \ Choicy.dylib"