### PR TITLE
Add iOS 15+ rootless jailbreak detection (palera1n/Dopamine) support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build Unsigned iOS IPA
+
+on:
+  push:
+    branches: [ fix-rootless-jailbreak-detection ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.2'
+
+      - name: Install CocoaPods dependencies
+        working-directory: DVIA-v2
+        run: pod install
+
+      - name: Build Unsigned App
+        working-directory: DVIA-v2
+        run: |
+          xcodebuild clean build \
+            -workspace DVIA-v2.xcworkspace \
+            -scheme DVIA-v2 \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CONFIGURATION_BUILD_DIR=$RUNNER_TEMP/build
+
+      - name: Package into IPA
+        run: |
+          cd $RUNNER_TEMP
+          mkdir Payload
+          mv build/*.app Payload/
+          zip -qr UnsignedApp.ipa Payload
+
+      - name: Upload IPA Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unsigned-iOS-IPA
+          path: ${{ runner.temp }}/UnsignedApp.ipa

--- a/DVIA-v2/DVIA-v2/Vulnerabilities/Jailbreak Detection/Controller/JailbreakDetectionViewController.swift
+++ b/DVIA-v2/DVIA-v2/Vulnerabilities/Jailbreak Detection/Controller/JailbreakDetectionViewController.swift
@@ -48,42 +48,6 @@ class JailbreakDetectionViewController: UIViewController {
         let barButton = UIBarButtonItem(customView: button)
         //assign button to navigationbar
         self.navigationItem.leftBarButtonItem = barButton
-        //let o = Obfuscator(withSalt: [AppDelegate.self, NSObject.self, NSString.self])
-        
-//        var bytes = o.bytesByObfuscatingString(string: "/Applications/Cydia.app")
-//        print(bytes)
-//        [116, 5, 38, 57, 45, 54, 21, 83, 90, 40, 31, 30, 55, 74, 47, 28, 3, 8, 21, 75, 77, 80, 62]
-//
-//        bytes = o.bytesByObfuscatingString(string: "/Library/MobileSubstrate/MobileSubstrate.dylib")
-//        print(bytes)
-//        [116, 8, 63, 43, 51, 62, 4, 75, 1, 12, 31, 18, 45, 9, 9, 54, 18, 3, 7, 17, 94, 65, 58, 54, 96, 47, 5, 7, 10, 24, 73, 115, 59, 49, 32, 0, 0, 8, 26, 2, 115, 63, 61, 58, 32, 35]
-//
-//        bytes = o.bytesByObfuscatingString(string: "/bin/bash")
-//        print(bytes)
-//        [116, 38, 63, 39, 110, 61, 23, 65, 70]
-//
-//
-//        bytes = o.bytesByObfuscatingString(string: "/usr/sbin/sshd")
-//        print(bytes)
-//        [116, 49, 37, 59, 110, 44, 20, 91, 64, 110, 3, 3, 44, 1]
-//
-//        bytes = o.bytesByObfuscatingString(string: "/Applications/Cydia.app")
-//        print(bytes)
-//        [116, 5, 38, 57, 45, 54, 21, 83, 90, 40, 31, 30, 55, 74, 47, 28, 3, 8, 21, 75, 77, 80, 62]
-//
-//        bytes = o.bytesByObfuscatingString(string: "/etc/apt")
-//        print(bytes)
-//        [116, 33, 34, 42, 110, 62, 6, 70]
-//
-//        bytes = o.bytesByObfuscatingString(string: "/private/jailbreak.txt")
-//        print(bytes)
-//        [116, 52, 36, 32, 55, 62, 2, 87, 1, 43, 17, 25, 40, 7, 30, 0, 6, 10, 90, 17, 84, 84]
-//
-//        bytes = o.bytesByObfuscatingString(string: "cydia://package/com.example.package")
-//        print(bytes)
-//        [56, 61, 50, 32, 32, 101, 89, 29, 94, 32, 19, 27, 37, 2, 9, 74, 4, 14, 25, 75, 73, 88, 47, 62, 63, 14, 15, 75, 19, 21, 79, 75, 47, 52, 54]
-        
-        // Do any additional setup after loading the view.
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -118,40 +82,66 @@ class JailbreakDetectionViewController: UIViewController {
     @IBAction func jailbreakTest4Tapped(_ sender: Any) {
         var isJailbroken:Bool = false
         #if !SIMULATOR
-            if FileManager.default.fileExists(atPath: "/Applications/Cydia.app") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/bin/bash") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/usr/sbin/sshd") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/etc/apt") {
-                isJailbroken = true
+            let suspiciousPaths = [
+                "/Applications/Cydia.app",
+                "/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/bin/bash",
+                "/usr/sbin/sshd",
+                "/etc/apt",
+                "/var/jb/Applications/Sileo.app",
+                "/var/jb/Applications/Zebra.app",
+                "/var/jb/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/var/jb/usr/lib/TweakInject",
+                "/var/jb/usr/bin/bash",
+                "/var/jb/usr/sbin/sshd",
+                "/var/jb/etc/apt",
+                "/var/jb/",
+                "/usr/lib/libhooker.dylib",
+                "/var/jb/usr/lib/libellekit.dylib"
+            ]
+            
+            for path in suspiciousPaths {
+                if FileManager.default.fileExists(atPath: path) {
+                    isJailbroken = true
+                    break
+                }
             }
             
-            var error: Error?
-            let stringToBeWritten = "This is a test."
-            do {
-                try stringToBeWritten.write(toFile: "/private/jailbreak.txt", atomically: true, encoding: .utf8)
-            } catch let err {
-                error = err
+            if !isJailbroken {
+                do {
+                    let _ = try FileManager.default.destinationOfSymbolicLink(atPath: "/var/jb")
+                    isJailbroken = true
+                } catch {}
             }
             
-            if error == nil {
-                //Device is jailbroken
-                isJailbroken = true
+            if !isJailbroken {
+                var error: Error?
+                let stringToBeWritten = "This is a test."
+                do {
+                    try stringToBeWritten.write(toFile: "/private/jailbreak.txt", atomically: true, encoding: .utf8)
+                } catch let err {
+                    error = err
+                }
+                
+                if error == nil {
+                    isJailbroken = true
+                    try? FileManager.default.removeItem(atPath: "/private/jailbreak.txt")
+                }
             }
-            else {
-                try? FileManager.default.removeItem(atPath: "/private/jailbreak.txt")
-            }
-            if UIApplication.shared.canOpenURL((URL(string: "cydia://package/com.example.package"))!) {
-                //Device is jailbroken
-                isJailbroken = true
+            
+            if !isJailbroken {
+                let suspiciousSchemes = [
+                    "cydia://package/com.example.package",
+                    "sileo://",
+                    "zbra://",
+                    "filza://"
+                ]
+                for scheme in suspiciousSchemes {
+                    if let url = URL(string: scheme), UIApplication.shared.canOpenURL(url) {
+                        isJailbroken = true
+                        break
+                    }
+                }
             }
         #endif
         
@@ -176,21 +166,34 @@ class JailbreakDetectionViewController: UIViewController {
     
     func isJailbroken() -> Bool {
         #if !SIMULATOR
-            if FileManager.default.fileExists(atPath: "/Applications/Cydia.app") {
-                return true
+            let suspiciousPaths = [
+                "/Applications/Cydia.app",
+                "/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/bin/bash",
+                "/usr/sbin/sshd",
+                "/etc/apt",
+                "/var/jb/Applications/Sileo.app",
+                "/var/jb/Applications/Zebra.app",
+                "/var/jb/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/var/jb/usr/lib/TweakInject",
+                "/var/jb/usr/bin/bash",
+                "/var/jb/usr/sbin/sshd",
+                "/var/jb/etc/apt",
+                "/var/jb/",
+                "/usr/lib/libhooker.dylib",
+                "/var/jb/usr/lib/libellekit.dylib"
+            ]
+            
+            for path in suspiciousPaths {
+                if FileManager.default.fileExists(atPath: path) {
+                    return true
+                }
             }
-            else if FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib") {
+            
+            do {
+                let _ = try FileManager.default.destinationOfSymbolicLink(atPath: "/var/jb")
                 return true
-            }
-            else if FileManager.default.fileExists(atPath: "/bin/bash") {
-                return true
-            }
-            else if FileManager.default.fileExists(atPath: "/usr/sbin/sshd") {
-                return true
-            }
-            else if FileManager.default.fileExists(atPath: "/etc/apt") {
-                return true
-            }
+            } catch {}
             
             var error: Error?
             let stringToBeWritten = "This is a test."
@@ -201,58 +204,88 @@ class JailbreakDetectionViewController: UIViewController {
             }
             
             if error == nil {
-                //Device is jailbroken
-                return true
-            }
-            else {
                 try? FileManager.default.removeItem(atPath: "/private/jailbreak.txt")
-            }
-            if UIApplication.shared.canOpenURL((URL(string: "cydia://package/com.example.package"))!) {
-                //Device is jailbroken
                 return true
+            }
+            
+            let suspiciousSchemes = [
+                "cydia://package/com.example.package",
+                "sileo://",
+                "zbra://",
+                "filza://"
+            ]
+            for scheme in suspiciousSchemes {
+                if let url = URL(string: scheme), UIApplication.shared.canOpenURL(url) {
+                    return true
+                }
             }
         #endif
-        //All checks have failed. Most probably, the device is not jailbroken
         return false
     }
     
     @inline(__always) func jailbreakTest3() {
         var isJailbroken:Bool = false
         #if !SIMULATOR
-            if FileManager.default.fileExists(atPath: "/Applications/Cydia.app") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/bin/bash") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/usr/sbin/sshd") {
-                isJailbroken = true
-            }
-            else if FileManager.default.fileExists(atPath: "/etc/apt") {
-                isJailbroken = true
+            let suspiciousPaths = [
+                "/Applications/Cydia.app",
+                "/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/bin/bash",
+                "/usr/sbin/sshd",
+                "/etc/apt",
+                "/var/jb/Applications/Sileo.app",
+                "/var/jb/Applications/Zebra.app",
+                "/var/jb/Library/MobileSubstrate/MobileSubstrate.dylib",
+                "/var/jb/usr/lib/TweakInject",
+                "/var/jb/usr/bin/bash",
+                "/var/jb/usr/sbin/sshd",
+                "/var/jb/etc/apt",
+                "/var/jb/",
+                "/usr/lib/libhooker.dylib",
+                "/var/jb/usr/lib/libellekit.dylib"
+            ]
+            
+            for path in suspiciousPaths {
+                if FileManager.default.fileExists(atPath: path) {
+                    isJailbroken = true
+                    break
+                }
             }
             
-            var error: Error?
-            let stringToBeWritten = "This is a test."
-            do {
-                try stringToBeWritten.write(toFile: "/private/jailbreak.txt", atomically: true, encoding: .utf8)
-            } catch let err {
-                error = err
+            if !isJailbroken {
+                do {
+                    let _ = try FileManager.default.destinationOfSymbolicLink(atPath: "/var/jb")
+                    isJailbroken = true
+                } catch {}
             }
             
-            if error == nil {
-                //Device is jailbroken
-                isJailbroken = true
+            if !isJailbroken {
+                var error: Error?
+                let stringToBeWritten = "This is a test."
+                do {
+                    try stringToBeWritten.write(toFile: "/private/jailbreak.txt", atomically: true, encoding: .utf8)
+                } catch let err {
+                    error = err
+                }
+                
+                if error == nil {
+                    isJailbroken = true
+                    try? FileManager.default.removeItem(atPath: "/private/jailbreak.txt")
+                }
             }
-            else {
-                try? FileManager.default.removeItem(atPath: "/private/jailbreak.txt")
-            }
-            if UIApplication.shared.canOpenURL((URL(string: "cydia://package/com.example.package"))!) {
-                //Device is jailbroken
-                isJailbroken = true
+            
+            if !isJailbroken {
+                let suspiciousSchemes = [
+                    "cydia://package/com.example.package",
+                    "sileo://",
+                    "zbra://",
+                    "filza://"
+                ]
+                for scheme in suspiciousSchemes {
+                    if let url = URL(string: scheme), UIApplication.shared.canOpenURL(url) {
+                        isJailbroken = true
+                        break
+                    }
+                }
             }
         #endif
         

--- a/DVIA-v2/DVIA-v2/Vulnerabilities/Jailbreak Detection/Objective-C Methods/JailbreakDetection.m
+++ b/DVIA-v2/DVIA-v2/Vulnerabilities/Jailbreak Detection/Objective-C Methods/JailbreakDetection.m
@@ -12,7 +12,6 @@
 //  And this https://www.youtube.com/watch?v=6dHXcoF590E
  
 
-
 #import <Foundation/Foundation.h>
 #import "JailbreakDetection.h"
 
@@ -22,38 +21,69 @@
     
 #if !(TARGET_IPHONE_SIMULATOR)
     
-    if ([[NSFileManager defaultManager] fileExistsAtPath:@"/Applications/Cydia.app"]){
-        return YES;
-    }else if([[NSFileManager defaultManager] fileExistsAtPath:@"/Library/MobileSubstrate/MobileSubstrate.dylib"]){
-        return YES;
-    }else if([[NSFileManager defaultManager] fileExistsAtPath:@"/bin/bash"]){
-        return YES;
-    }else if([[NSFileManager defaultManager] fileExistsAtPath:@"/usr/sbin/sshd"]){
-        return YES;
-    }else if([[NSFileManager defaultManager] fileExistsAtPath:@"/etc/apt"]){
-        return YES;
+    // 1. Array of traditional AND modern rootless paths
+    NSArray *suspiciousPaths = @[
+        // Traditional Rootful Paths
+        @"/Applications/Cydia.app",
+        @"/Library/MobileSubstrate/MobileSubstrate.dylib",
+        @"/bin/bash",
+        @"/usr/sbin/sshd",
+        @"/etc/apt",
+        
+        // Modern Rootless Paths (palera1n, Dopamine, etc.)
+        @"/var/jb/Applications/Sileo.app",
+        @"/var/jb/Applications/Zebra.app",
+        @"/var/jb/Library/MobileSubstrate/MobileSubstrate.dylib",
+        @"/var/jb/usr/lib/TweakInject",
+        @"/var/jb/usr/bin/bash",
+        @"/var/jb/usr/sbin/sshd",
+        @"/var/jb/etc/apt",
+        @"/usr/lib/libhooker.dylib",
+        @"/var/jb/usr/lib/libellekit.dylib"
+    ];
+    
+    for (NSString *path in suspiciousPaths) {
+        if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+            return YES;
+        }
     }
     
+    // 2. Symlink Check for Rootless
+    NSError *symlinkError = nil;
+    NSString *symlinkDest = [[NSFileManager defaultManager] destinationOfSymbolicLinkAtPath:@"/var/jb" error:&symlinkError];
+    if (symlinkDest != nil) {
+        return YES; // Highly indicative of a rootless jailbreak
+    }
+    
+    // 3. Sandbox Write Check
     NSError *error;
     NSString *stringToBeWritten = @"This is a test.";
     [stringToBeWritten writeToFile:@"/private/jailbreak.txt" atomically:YES
                           encoding:NSUTF8StringEncoding error:&error];
-    if(error==nil){
-        //Device is jailbroken
-        return YES;
-    } else {
+    if(error == nil){
+        // Device is jailbroken
         [[NSFileManager defaultManager] removeItemAtPath:@"/private/jailbreak.txt" error:nil];
+        return YES;
     }
     
-    if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"cydia://package/com.example.package"]]){
-        //Device is jailbroken
-        return YES;
+    // 4. Modern URL Scheme Checks
+    NSArray *suspiciousSchemes = @[
+        @"cydia://package/com.example.package",
+        @"sileo://",
+        @"zbra://",
+        @"filza://"
+    ];
+    
+    for (NSString *scheme in suspiciousSchemes) {
+        if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
+            return YES;
+        }
     }
+    
 #endif
     
-    //All checks have failed. Most probably, the device is not jailbroken
+    // All checks have failed. Most probably, the device is not jailbroken
     return NO;
 }
-
 
 @end

--- a/DVIA-v2/Podfile
+++ b/DVIA-v2/Podfile
@@ -1,4 +1,5 @@
 use_frameworks!
+platform :ios, '12.0'
 
 target 'DVIA-v2' do
     pod 'Parse'
@@ -11,5 +12,11 @@ end
 post_install do |installer|
   installer.pods_project.build_configurations.each do |config|
     config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+  end
+
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "12.0"
+    end
   end
 end


### PR DESCRIPTION
Updated the jailbreak detection logic in both Swift and Objective-C modules to accurately detect modern rootless jailbreaks (such as palera1n and Dopamine).

Key changes include:
- Added checks for modern rootless filesystem paths (e.g., `/var/jb/Applications/Sileo.app`, `/var/jb/usr/lib/TweakInject`).
- Implemented a symlink check for `/var/jb`, which is highly indicative of rootless environments.
- Added URL scheme checks for modern package managers (Sileo, Zebra, Filza).
- Preserved all existing legacy/rootful checks to ensure backward compatibility.